### PR TITLE
fix: FILES-302 - Fix postgresql dependency on RHEL

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,17 +64,17 @@ pipeline {
                                 }
                             }
                         }
-                        stage('RHEL 8') {
+                        stage('Rocky 8') {
                             agent {
                                 node {
-                                    label 'pacur-agent-centos-8-v1'
+                                    label 'pacur-agent-rocky-8-v1'
                                 }
                             }
                             steps {
                                 dir('/tmp/staging') {
                                   unstash 'binaries'
                                 }
-                                sh 'sudo pacur build centos /tmp/staging/'
+                                sh 'sudo pacur build rocky-8 /tmp/staging/'
                                 dir("artifacts/") {
                                     sh 'echo carbonio-files-db* | sed -E "s#(carbonio-files-db-[0-9.]*).*#\\0 \\1.x86_64.rpm#" | xargs sudo mv'
                                 }
@@ -167,7 +167,7 @@ pipeline {
                     Artifactory.addInteractivePromotion server: server, promotionConfig: config, displayName: "Ubuntu Promotion to Release"
                     server.publishBuildInfo buildInfo
 
-                    //centos8
+                    //rocky 8
                     buildInfo = Artifactory.newBuildInfo()
                     buildInfo.name += "-centos8"
                     uploadSpec= """{

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,7 +3,7 @@ targets=(
   "ubuntu"
 )
 pkgname="carbonio-files-db"
-pkgver="0.1.2"
+pkgver="0.1.3"
 pkgrel="1"
 pkgdesc="Carbonio Files DB sidecar"
 pkgdesclong=(
@@ -15,11 +15,18 @@ section="mail"
 priority="optional"
 arch="amd64"
 license=("spdx:AGPL-3.0-only")
-depends=(
+depends:apt=(
   "service-discover"
   "pending-setups"
   "carbonio-core"
   "postgresql-client"
+)
+
+depends:yum=(
+  "service-discover"
+  "pending-setups"
+  "carbonio-core"
+  "postgresql"
 )
 
 sources=(


### PR DESCRIPTION
In debian based distro the psql tool is contained in the
postgresql-client package. In RHEL based distro the tool is contained in
the postgresql package. The PKBGUILD was changed accordingly.

A minor changed was made in the Jenkinsfile in order to replace the
pacur build target from centos8 to rocky8.