### PR TITLE
ci: add timestamp and commit hash for each commit in develop

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,22 @@ pipeline {
         }
         stage('Build deb/rpm') {
             stages {
+                // Replace the pkgrel value with the git commit hash to ensure that
+                // each merged PR has unique artifacts and to prevent conflicts between them.
+                // Note that the pkgrel value will remain as it was in the codebase to avoid
+                // conflicts between multiple open PRs
+                stage('Add timestamp and commit hash') {
+                    when {
+                        branch 'develop'
+                    }
+                    steps {
+                        sh'''
+                            export TIMESTAMP=$(date +%s)
+                            export GIT_COMMIT_SHORT=$(git rev-parse HEAD | head -c 8)
+                            sed -i "s/pkgrel=\\".*\\"/pkgrel=\\"$TIMESTAMP+$GIT_COMMIT_SHORT\\"/" ./package/PKGBUILD
+                        '''
+                    }
+                }
                 stage('Stash') {
                     steps {
                         stash includes: "yap.json,package/**", name: 'binaries'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,6 +99,7 @@ pipeline {
             }
             steps {
                 unstash 'artifacts-deb'
+                unstash 'artifacts-rpm'
                 script {
                     def server = Artifactory.server 'zextras-artifactory'
                     def buildInfo

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-files-db"
-pkgver="0.1.6"
-pkgrel="1"
+pkgver="0.1.7"
+pkgrel="SNAPSHOT"
 pkgdesc="Carbonio Files DB sidecar"
 maintainer="Zextras <packages@zextras.com>"
 url="https://zextras.com"


### PR DESCRIPTION
- Added command to replace pkgrel for every build in develop with timestamp and commit hash
- Fixed "Upload to Develop" stage unstashing "artifacts-rpm" 

Refs: IN-712