### PR TITLE
chore: carbonio.target should restart the services not covered by zmcontrol

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 pkgname="carbonio-files-db"
-pkgver="0.1.7"
+pkgver="0.1.8"
 pkgrel="1"
 pkgdesc="Carbonio Files DB sidecar"
 maintainer="Zextras <packages@zextras.com>"

--- a/package/carbonio-files-db-sidecar.service
+++ b/package/carbonio-files-db-sidecar.service
@@ -7,6 +7,7 @@ Description=Carbonio Files database sidecar
 Documentation=https://docs.zextras.com/
 Requires=network-online.target
 After=network-online.target
+PartOf=carbonio.target
 
 [Service]
 Type=simple
@@ -24,4 +25,4 @@ TimeoutSec=120
 TimeoutStopSec=120
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=carbonio.target


### PR DESCRIPTION
Refs: IN-881