### PR TITLE
Revert WantedBy for compatibility with older systems

### DIFF
--- a/package/carbonio-files-db-sidecar.service
+++ b/package/carbonio-files-db-sidecar.service
@@ -22,4 +22,4 @@ KillSignal=SIGINT
 LimitNOFILE=65536
 
 [Install]
-WantedBy=carbonio.target
+WantedBy=multi-user.target


### PR DESCRIPTION
Some changes introduced by IN-881 (#17) are not compatible with older systems.
Centos8 and ubuntu22 still use init.d, therefore some units were not activated at startup.

Solution: revert the `WantedBy=` to `multi-user.target` where modified.

Refs: IN-919 IN-881