### PR TITLE
chore:  [CO-3381] sidecar image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,6 +116,18 @@ pipeline {
             }
         }
 
+        stage('Publish docker images') {
+            steps {
+                dockerStage([
+                    dockerfile: 'docker/files-db-sidecar/Dockerfile',
+                    imageName: 'carbonio-files-db-sidecar',
+                    ocLabels: [
+                        title: 'Carbonio Files DB Sidecar',
+                    ]
+                ])
+            }
+        }
+
         stage('Tag for release') {
             when {
                 allOf {

--- a/docker/files-db-sidecar/Dockerfile
+++ b/docker/files-db-sidecar/Dockerfile
@@ -29,12 +29,15 @@ ENTRYPOINT ["/bin/sh", "-c", "\
   echo '[sidecar] Waiting for consul agent...' && \
   until consul members >/dev/null 2>&1; do sleep 1; done && \
   echo '[sidecar] Consul agent ready.' && \
-  consul services register /consul/config/*.hcl && \
-  (carbonio-files-db setup || true) && \
   echo '[sidecar] Waiting for postgres...' && \
   until pg_isready -h $POSTGRES_HOST -p $POSTGRES_PORT >/dev/null 2>&1; do sleep 1; done && \
-  echo '[sidecar] Postgres ready, running bootstrap...' && \
-  (carbonio-files-db-bootstrap $POSTGRES_USER $POSTGRES_HOST $POSTGRES_PORT || true) && \
+  until PGPASSWORD=$PGPASSWORD psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER -w -c 'SELECT 1' >/dev/null 2>&1; do sleep 1; done && \
+  echo '[sidecar] Postgres ready.' && \
+  consul services register /consul/config/*.hcl && \
+  echo '[sidecar] Running setup...' && \
+  carbonio-files-db setup && \
+  echo '[sidecar] Running bootstrap...' && \
+  (carbonio-files-db-bootstrap $POSTGRES_USER $POSTGRES_HOST || true) && \
   echo '[sidecar] Starting envoy for $SERVICE_NAME' && \
   exec consul connect envoy \
     -sidecar-for=$SERVICE_NAME \

--- a/docker/files-db-sidecar/Dockerfile
+++ b/docker/files-db-sidecar/Dockerfile
@@ -1,5 +1,8 @@
 FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
 
+# psql is needed by the bootstrap script to create the database
+RUN apt-get update && apt-get install -y postgresql-client openssl && rm -rf /var/lib/apt/lists/*
+
 # Service registration
 COPY package/carbonio-files-db.hcl /consul/config/
 
@@ -12,7 +15,15 @@ COPY package/policies.json         /etc/carbonio/files-db/service-discover/
 COPY package/carbonio-files-db /usr/local/bin/carbonio-files-db
 RUN chmod +x /usr/local/bin/carbonio-files-db
 
+# Bootstrap script (creates DB user, database, saves credentials to consul KV)
+COPY package/carbonio-files-db-bootstrap /usr/local/bin/carbonio-files-db-bootstrap
+RUN chmod +x /usr/local/bin/carbonio-files-db-bootstrap
+
 ENV SERVICE_NAME=carbonio-files-db
+ENV PGPASSWORD=admin
+ENV POSTGRES_USER=admin
+ENV POSTGRES_HOST=localhost
+ENV POSTGRES_PORT=5432
 
 ENTRYPOINT ["/bin/sh", "-c", "\
   echo '[sidecar] Waiting for consul agent...' && \
@@ -20,6 +31,10 @@ ENTRYPOINT ["/bin/sh", "-c", "\
   echo '[sidecar] Consul agent ready.' && \
   consul services register /consul/config/*.hcl && \
   (carbonio-files-db setup || true) && \
+  echo '[sidecar] Waiting for postgres...' && \
+  until pg_isready -h $POSTGRES_HOST -p $POSTGRES_PORT >/dev/null 2>&1; do sleep 1; done && \
+  echo '[sidecar] Postgres ready, running bootstrap...' && \
+  (carbonio-files-db-bootstrap $POSTGRES_USER $POSTGRES_HOST $POSTGRES_PORT || true) && \
   echo '[sidecar] Starting envoy for $SERVICE_NAME' && \
   exec consul connect envoy \
     -sidecar-for=$SERVICE_NAME \

--- a/docker/files-db-sidecar/Dockerfile
+++ b/docker/files-db-sidecar/Dockerfile
@@ -1,0 +1,27 @@
+FROM registry.dev.zextras.com/dev/carbonio-sidecar:latest
+
+# Service registration
+COPY package/carbonio-files-db.hcl /consul/config/
+
+# Setup files at the path the setup script expects
+COPY package/service-protocol.json /etc/carbonio/files-db/service-discover/
+COPY package/intentions.json       /etc/carbonio/files-db/service-discover/
+COPY package/policies.json         /etc/carbonio/files-db/service-discover/
+
+# Setup script
+COPY package/carbonio-files-db /usr/local/bin/carbonio-files-db
+RUN chmod +x /usr/local/bin/carbonio-files-db
+
+ENV SERVICE_NAME=carbonio-files-db
+
+ENTRYPOINT ["/bin/sh", "-c", "\
+  echo '[sidecar] Waiting for consul agent...' && \
+  until consul members >/dev/null 2>&1; do sleep 1; done && \
+  echo '[sidecar] Consul agent ready.' && \
+  consul services register /consul/config/*.hcl && \
+  (carbonio-files-db setup || true) && \
+  echo '[sidecar] Starting envoy for $SERVICE_NAME' && \
+  exec consul connect envoy \
+    -sidecar-for=$SERVICE_NAME \
+    -admin-bind=localhost:0 \
+"]

--- a/docker/files-db-sidecar/Dockerfile
+++ b/docker/files-db-sidecar/Dockerfile
@@ -35,7 +35,7 @@ ENTRYPOINT ["/bin/sh", "-c", "\
   echo '[sidecar] Postgres ready.' && \
   consul services register /consul/config/*.hcl && \
   echo '[sidecar] Running setup...' && \
-  carbonio-files-db setup && \
+  (carbonio-files-db setup || true) && \
   echo '[sidecar] Running bootstrap...' && \
   (carbonio-files-db-bootstrap $POSTGRES_USER $POSTGRES_HOST || true) && \
   echo '[sidecar] Starting envoy for $SERVICE_NAME' && \


### PR DESCRIPTION
Adds sidecar image to be used in a container environment and enable service-to-service mesh communication in Consul.

It reuses most of the scripts and files used in the VM.

TODO:
- [ ] add token file
- [ ] think if we can reuse the entrypoint layer and define it in the parent image