### PR TITLE
fix: restore buildPackages() to fix pkgrel on tag builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,11 +59,16 @@ pipeline {
 
         stage('Build deb/rpm') {
             steps {
-                buildPackages([
-                    buildStageConfig: [
-                        buildFlags: ' -ds ',
-                    ]
-                ])
+                script {
+                    buildPackages([
+                        pkgbuildPath: 'package/PKGBUILD',
+                        buildStageConfig: [
+                            buildFlags: ' -ds ',
+                            rockySinglePkg: true,
+                            ubuntuSinglePkg: true
+                        ]
+                    ])
+                }
             }
         }
 
@@ -77,6 +82,8 @@ pipeline {
             steps {
                 uploadStage(
                     packages: yapHelper.resolvePackageNames(),
+                    rockySinglePkg: true,
+                    ubuntuSinglePkg: true
                 )
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,8 +59,10 @@ pipeline {
 
         stage('Build deb/rpm') {
             steps {
-                buildStage([
-                    buildFlags: ' -ds ',
+                buildPackages([
+                    buildStageConfig: [
+                        buildFlags: ' -ds ',
+                    ]
                 ])
             }
         }


### PR DESCRIPTION
## Summary
- Restores `buildPackages()` wrapper that was removed in CO-3422 batch commit (Apr 8)
- `buildStage()` alone does not call `updatePkgbuildRelease()`, causing SNAPSHOT pkgrel to leak into RC artifacts on tag builds
- `buildPackages()` calls `updatePkgbuildRelease()` → `buildStage()` → git checkout, ensuring pkgrel=1 on releases

## Test plan
- [ ] Verify devel branch build still produces SNAPSHOT packages
- [ ] Verify tag build produces pkgrel=1 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)