### PR TITLE
feat(packaging): use arch=('any') for architecture-independent package

### DIFF
--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -10,7 +10,7 @@ maintainer="Zextras <packages@zextras.com>"
 url="https://zextras.com"
 section="mail"
 priority="optional"
-arch=('x86_64')
+arch=('any')
 license=("AGPL-3.0-only")
 depends__apt=(
   "service-discover"


### PR DESCRIPTION
## Summary

- Replace `arch=('x86_64')` with `arch=('any')` in PKGBUILD since this package does not contain architecture-specific binaries

IN-951