### PR TITLE
ci: migrate to dt3_pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,16 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-dt3-lib@v1.2.0',
-    retriever: modernSCM([
-        $class: 'GitSCMSource',
-        remote: 'git@github.com:zextras/jenkins-dt3-lib.git',
-        credentialsId: 'jenkins-integration-with-github-account'
-    ])
-)
-
-library(
-    identifier: 'jenkins-lib-common@1.7.5',
+    identifier: 'jenkins-lib-common@dt3-migration',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',
@@ -20,126 +11,16 @@ library(
     ])
 )
 
-properties(defaultPipelineProperties())
-
-pipeline {
-    agent {
-        node {
-            label 'zextras-v1'
-        }
-    }
-
-    environment {
-        LC_ALL = 'C.UTF-8'
-    }
-
-    options {
-        buildDiscarder(logRotator(numToKeepStr: '25'))
-        skipDefaultCheckout()
-        timeout(time: 30, unit: 'MINUTES')
-    }
-
-    parameters {
-        booleanParam(
-            name: 'PREPARE_RELEASE',
-            defaultValue: false,
-            description: 'Check this to prepare a new release (creates pre-release branch and PR)'
-        )
-    }
-
-    stages {
-        stage('Setup') {
-            steps {
-                checkout scm
-                script {
-                    gitMetadata()
-                }
-            }
-        }
-
-        stage('Build deb/rpm') {
-            steps {
-                script {
-                    buildPackages([
-                        pkgbuildPath: 'package/PKGBUILD',
-                        buildStageConfig: [
-                            buildFlags: ' -ds '
-                        ]
-                    ])
-                }
-            }
-        }
-
-        stage('Upload artifacts') {
-            when {
-                expression { return uploadStage.shouldUpload() }
-            }
-            tools {
-                jfrog 'jfrog-cli'
-            }
-            steps {
-                uploadStage(
-                    packages: yapHelper.resolvePackageNames()
-                )
-            }
-        }
-
-        stage('Prepare Release') {
-            agent {
-                node {
-                    label 'sm-release-v1'
-                }
-            }
-            when {
-                allOf {
-                    branch 'devel'
-                    expression { params.PREPARE_RELEASE == true }
-                    not {
-                        expression {
-                            return env.GIT_COMMIT_MSG.contains('[skip ci]') ||
-                                   env.GIT_COMMIT_MSG.contains('chore(release):')
-                        }
-                    }
-                }
-            }
-            steps {
-                script {
-                    container('nodejs-22') {
-                        prepareRelease(
-                            repoName: 'carbonio-files-db'
-                        )
-                    }
-                }
-            }
-        }
-
-        stage('Publish docker images') {
-            steps {
-                dockerStage([
-                    dockerfile: 'docker/files-db-sidecar/Dockerfile',
-                    imageName: 'carbonio-files-db-sidecar',
-                    ocLabels: [
-                        title: 'Carbonio Files DB Sidecar',
-                    ]
-                ])
-            }
-        }
-
-        stage('Tag for release') {
-            when {
-                allOf {
-                    branch 'devel'
-                    expression {
-                        return env.GIT_COMMIT_MSG.contains('chore(release):') &&
-                               env.GIT_COMMIT_MSG.contains('[skip ci]')
-                    }
-                }
-            }
-            steps {
-                script {
-                    tagRelease()
-                }
-            }
-        }
-    }
-}
+dt3_pipeline(
+    repoName: 'carbonio-files-db',
+    packaging: [
+        pkgbuildPath: 'package/PKGBUILD',
+        buildFlags: '-ds',
+    ],
+    docker: [[
+        dockerfile: 'docker/files-db-sidecar/Dockerfile',
+        imageName: 'carbonio-files-db-sidecar',
+        title: 'Carbonio Files DB Sidecar',
+        description: 'Carbonio Files DB sidecar service',
+    ]],
+)


### PR DESCRIPTION
## Summary

- Migrates `jenkins-lib-common` to `dt3-migration`
- Replaces the explicit `pipeline {}` block (which called `buildPackages`, `prepareRelease`, `tagRelease` from the now-superseded `jenkins-dt3-lib`) with the unified `dt3_pipeline()` entrypoint from `jenkins-lib-common`

## Root cause of the build failure

`buildPackages`, `prepareRelease`, and `tagRelease` are defined in `jenkins-dt3-lib`, not in `jenkins-lib-common`. Loading only the latter and calling the former caused `NoSuchMethodError` at runtime.

## Behavioural changes

- Release param renamed: `PREPARE_RELEASE` → `RELEASE`
- Package builds now use single-pkg mode (`ubuntuSinglePkg`/`rockySinglePkg` = true) — correct for `arch=('any')`
- Timeout: 30 min → 2 h (dt3_pipeline default)
- Full git clone (non-shallow) required by `dt3_resolveVersion()`