### PR TITLE
feat(ci): [IN-951] add arm64 platform to docker image builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ dt3_pipeline(
     docker: [[
         dockerfile: 'docker/files-db-sidecar/Dockerfile',
         imageName: 'carbonio-files-db-sidecar',
+        platforms: ['linux/amd64', 'linux/arm64'] as Set,
         title: 'Carbonio Files DB Sidecar',
         description: 'Carbonio Files DB sidecar service',
     ]],

--- a/docker/files-db-sidecar/Dockerfile
+++ b/docker/files-db-sidecar/Dockerfile
@@ -1,7 +1,48 @@
+# psql + openssl are needed by the bootstrap/setup scripts. The carbonio-sidecar
+# base is ubuntu jammy; installing postgresql-client/openssl with apt in the
+# final stage runs target-arch maintainer scripts (no QEMU => exec format error
+# on arm64).
+#
+# Instead, cross-download the target-arch .debs on the BUILDPLATFORM (amd64 CI
+# builder) from ports.ubuntu.com, extract them with dpkg -x (no maintainer
+# scripts execute), and assemble a minimal tree of just the binaries + the libs
+# the base does NOT already provide. libssl/libcrypto/libgssapi/libgnutls/
+# libtinfo are already in the base, so we ship only: libpq, libldap-2.5,
+# liblber-2.5, libsasl2, libreadline. Everything goes under /usr/lib (not /lib):
+# ubuntu jammy is usrmerged so /lib is a symlink to /usr/lib, and COPYing into
+# /lib/* fails on some buildkit versions ("cannot copy to non-directory").
+FROM --platform=$BUILDPLATFORM ubuntu:jammy AS pgclient
+ARG TARGETARCH
+RUN set -eux; \
+    case "$TARGETARCH" in \
+      arm64) TRIPLET=aarch64-linux-gnu ;; \
+      amd64) TRIPLET=x86_64-linux-gnu ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    dpkg --add-architecture "${TARGETARCH}"; \
+    if [ "$TARGETARCH" != "amd64" ]; then \
+      sed -i 's|http://archive.ubuntu.com/ubuntu/|[arch=amd64] http://archive.ubuntu.com/ubuntu/|; s|http://security.ubuntu.com/ubuntu/|[arch=amd64] http://security.ubuntu.com/ubuntu/|' /etc/apt/sources.list; \
+      printf 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main universe\ndeb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main universe\ndeb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main universe\n' > /etc/apt/sources.list.d/arm64.list; \
+    fi; \
+    apt-get update; \
+    mkdir -p /dl /x /out/usr/bin "/out/usr/lib/${TRIPLET}"; \
+    apt-get install -y --download-only -o Dir::Cache::archives=/dl \
+      postgresql-client-14:${TARGETARCH} libpq5:${TARGETARCH} openssl:${TARGETARCH}; \
+    for d in /dl/*.deb; do dpkg -x "$d" /x; done; \
+    cp -a /x/usr/lib/postgresql/14/bin/psql        /out/usr/bin/psql; \
+    cp -a /x/usr/lib/postgresql/14/bin/pg_isready   /out/usr/bin/pg_isready; \
+    cp -a /x/usr/bin/openssl                        /out/usr/bin/openssl; \
+    cp -a /x/usr/lib/${TRIPLET}/libpq.so.*          "/out/usr/lib/${TRIPLET}/"; \
+    cp -a /x/usr/lib/${TRIPLET}/libldap-2.5.so.*    "/out/usr/lib/${TRIPLET}/"; \
+    cp -a /x/usr/lib/${TRIPLET}/liblber-2.5.so.*    "/out/usr/lib/${TRIPLET}/"; \
+    cp -a /x/usr/lib/${TRIPLET}/libsasl2.so.*       "/out/usr/lib/${TRIPLET}/"; \
+    cp -a /x/lib/${TRIPLET}/libreadline.so.*        "/out/usr/lib/${TRIPLET}/"
+
 FROM registry.dev.zextras.com/dev/carbonio-sidecar:devel
 
-# psql is needed by the bootstrap script to create the database
-RUN apt-get update && apt-get install -y postgresql-client openssl && rm -rf /var/lib/apt/lists/*
+# psql + pg_isready + openssl + their not-already-present shared libs
+# (arch-matched, cross-downloaded above). No target-arch RUN => QEMU-free.
+COPY --from=pgclient /out /
 
 # Service registration
 COPY package/carbonio-files-db.hcl /consul/config/
@@ -11,13 +52,11 @@ COPY package/service-protocol.json /etc/carbonio/files-db/service-discover/
 COPY package/intentions.json       /etc/carbonio/files-db/service-discover/
 COPY package/policies.json         /etc/carbonio/files-db/service-discover/
 
-# Setup script
-COPY package/carbonio-files-db /usr/local/bin/carbonio-files-db
-RUN chmod +x /usr/local/bin/carbonio-files-db
+# Setup script (COPY --chmod avoids a target-arch RUN — QEMU-free)
+COPY --chmod=755 package/carbonio-files-db /usr/local/bin/carbonio-files-db
 
 # Bootstrap script (creates DB user, database, saves credentials to consul KV)
-COPY package/carbonio-files-db-bootstrap /usr/local/bin/carbonio-files-db-bootstrap
-RUN chmod +x /usr/local/bin/carbonio-files-db-bootstrap
+COPY --chmod=755 package/carbonio-files-db-bootstrap /usr/local/bin/carbonio-files-db-bootstrap
 
 ENV SERVICE_NAME=carbonio-files-db
 ENV PGPASSWORD=admin


### PR DESCRIPTION
Adds arm64 multi-arch support. **Depends on jenkins-lib-common#108** (forwards per-image `platforms` through `dt3_pipeline`). Sidecar Dockerfile refactored to the no-QEMU cross-download pattern: psql/pg_isready/openssl + missing shared libs are cross-downloaded as target-arch .debs on $BUILDPLATFORM and extracted with dpkg -x (no target-arch RUN, no QEMU). `platforms: [...] as Set` added to the docker entry.