### PR TITLE
fix(ci): build packages for all distros

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@ dt3_pipeline(
     packaging: [
         pkgbuildPath: 'package/PKGBUILD',
         buildFlags: '-ds',
+        rockySinglePkg: false,
+        ubuntuSinglePkg: false,
     ],
     docker: [[
         dockerfile: 'docker/files-db-sidecar/Dockerfile',


### PR DESCRIPTION
Add `rockySinglePkg: false` and `ubuntuSinglePkg: false` to the `packaging` map in `dt3_pipeline()` to ensure packages are built for all supported distributions.

CO-3709